### PR TITLE
Removed range download for better speed, added mp3 extract, improved progress print

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ func main() {
 	video, err := youtube.Get("FTl0tl9BGdc")
 
 	// download the video and write to file
-	video.download(0, "video.mp4")
+	option := &youtube.Option{
+		Rename: true,  // rename file using video title
+		Resume: true,  // resume cancelled download
+		Mp3:    true,  // extract audio to MP3
+	}
+	video.Download(0, "video.mp4", option)
 }
-
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # go-get-youtube v 0.2
-A tiny Go library + client (command line Youtube video downloader) for downloading Youtube videos. The library is capable of fetching Youtube video metadata, in addition to downloading videos.
+A tiny Go library + client (command line Youtube video downloader) for downloading Youtube videos. The library is capable of fetching Youtube video metadata, in addition to downloading videos. If ffmpeg is available, client can extract MP3 audio from downloaded video files.
 
 Kailash Nadh, http://nadh.in --
 27 February 2014
@@ -11,7 +11,18 @@ Once you have compiled or [downloaded](https://github.com/knadh/go-get-youtube/r
 
 `ytdownload -id=youtube_video_id`
 
+## Building
+```
+$ export GOPATH=$PWD/go-get-youtube
+$ go get github.com/knadh/go-get-youtube
+$ cd go-get-youtube/bin
+$ ./go-get-youtube -id=cN_DpYBzKso -itag 18 -rename -mp3
 
+Extracted audio: cN_DpYBzKso-rob-pike-concurrency-is-not-parallelis.mp3
+Download duration: 5s
+Average speed: 16.1MB/s
+Downloaded video: cN_DpYBzKso-rob-pike-concurrency-is-not-parallelism.mp4
+```
 # Library
 
 ## Methods
@@ -37,9 +48,15 @@ type Format struct {
 	Itag int
 	Video_type, Quality, Url string
 }
+
+type Option struct {
+	Resume bool // resume failed or cancelled download
+	Rename bool // rename output file using video title
+	Mp3    bool // extract audio using ffmpeg
+}
 ```
 
-### youtube.Download(format_index, output_file)
+### youtube.Download(format_index, output_file, option)
 `format_index` is the index of the format listed in the `Video.Formats` array. Youtube offers a number of video formats (mp4, webm, 3gp etc.)
 
 ### youtube.GetExtension(format_index)
@@ -64,3 +81,8 @@ func main() {
 	video.Download(0, "video.mp4", option)
 }
 ```
+
+
+## Contributors
+
+Batbold Dashzeveg


### PR DESCRIPTION
- Not using range requests because Youtube is throttling download speed
- Using output file offset for measuring download speed
- Added '-mp3' switch for extracting audio from downloaded video (requires ffmpeg with mp3 encoder)
- Updated README documentation

Thank you Kailash for creating the useful library and accepting my contributions.
