### PR TITLE
Add error when trying to download 403 Forbidden videos from Youtube Music

### DIFF
--- a/youtube/yotube.go
+++ b/youtube/yotube.go
@@ -10,7 +10,7 @@
 	License: GPL v2
 **/
 
-package main
+package youtube
 
 import (
 	"errors"

--- a/youtube/yotube.go
+++ b/youtube/yotube.go
@@ -10,7 +10,7 @@
 	License: GPL v2
 **/
 
-package youtube
+package main
 
 import (
 	"errors"
@@ -124,11 +124,16 @@ func (video *Video) Download(index int, filename string, option *Option) error {
 	if resp, err := http.Head(url); err != nil {
 		return fmt.Errorf("Head request failed: %s", err)
 	} else {
+		if resp.StatusCode == 403 {
+			return errors.New("Head request failed: Video is 403 forbidden")
+		}
+
 		if size := resp.Header.Get("Content-Length"); len(size) == 0 {
 			return errors.New("Content-Length header is missing")
 		} else if length, err = strconv.ParseInt(size, 10, 64); err != nil {
 			return fmt.Errorf("Invalid Content-Length: %s", err)
 		}
+
 		if length <= offset {
 			fmt.Println("Video file is already downloaded.")
 			return nil
@@ -186,7 +191,7 @@ func (video *Video) Download(index int, filename string, option *Option) error {
 		if err != nil {
 			fmt.Println("ffmpeg not found")
 		} else {
-			fmt.Println("Extracting autio ..")
+			fmt.Println("Extracting audio ..")
 			fname := video.Filename
 			mp3 := strings.TrimRight(fname, filepath.Ext(fname)) + ".mp3"
 			cmd := exec.Command(ffmpeg, "-y", "-loglevel", "quiet", "-i", fname, "-vn", mp3)


### PR DESCRIPTION
If you try to download something from Youtube Music (for example [this video](https://www.youtube.com/watch?v=JfGD75vHWrU)) using the utility, the ``HEAD`` request in ``yotube.go:124`` would get a ``403 Forbidden``. This is silently ignored and the routine instead says "Video file is already downloaded" at ``yotube.go:137``. This pull request adds an error check for the 403 Forbidden code.

Also, fixed a typo